### PR TITLE
Update voiceStateUpdate.js

### DIFF
--- a/src/events/voiceStateUpdate.js
+++ b/src/events/voiceStateUpdate.js
@@ -36,7 +36,7 @@ module.exports = (client, oldState, newState) => {
         const channel = oldState.channel;
 
         // Voice Channel Verification
-        if (channel.parent.id !== Guild.channels.category || channel.id === Guild.channels.voice) return;
+        if (channel.parent == null || channel.parent.id !== Guild.channels.category || channel.id === Guild.channels.voice) return;
         if (channel.members.array().length) return;
 
         // NeDB VoiceChannels Removal


### PR DESCRIPTION
Fixes a case where if a voice channel was not in a category, it would crash the Bot!